### PR TITLE
Refine landing page hero and CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 <body class="text-gray-900 antialiased text-base leading-relaxed">
   <!-- Header -->
   <header class="sticky top-0 z-20 backdrop-blur-md bg-white/70 shadow md:shadow-none md:bg-transparent flex items-center justify-between max-w-7xl mx-auto px-4 md:px-8 py-4 md:py-6">
-    <img src="assets/hawalabit-logo.svg" alt="HawalaBit Logo" class="h-10 w-auto" />
+    <img src="hawalabit-logo.svg" alt="HawalaBit Logo" class="h-10 w-auto" />
     
     <input type="checkbox" id="nav-toggle" class="peer hidden" />
     <label for="nav-toggle" class="md:hidden cursor-pointer">
@@ -44,11 +44,11 @@
 
   <!-- Hero -->
   <section class="bg-gradient-to-r from-blue-500 via-purple-500 to-indigo-600 bg-animated py-20 text-center px-4 text-white" id="hero">
-    <h1 class="text-5xl md:text-6xl font-bold font-playfair">Global Money. Human Trust. Instant Access.</h1>
+    <h1 class="text-4xl md:text-6xl font-bold font-playfair">Global Money. Human Trust. Instant Access.</h1>
     <p class="mt-4 text-xl leading-relaxed">Send, receive, and spend across borders—without banks or delays.</p>
     <div class="mt-8 flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
-      <a href="#cta" class="px-8 py-3 bg-blue-600 text-white rounded-md font-semibold transition transform hover:scale-105 hover:shadow-lg">Request Early Access</a>
-      <a href="#how" class="px-8 py-3 border border-white/70 text-white rounded-md font-semibold transition transform hover:scale-105 hover:shadow-lg">How It Works</a>
+      <a href="#cta" class="px-8 py-3 bg-blue-600 text-white rounded-md font-semibold transition transform hover:scale-105 hover:bg-blue-700">Request Early Access</a>
+      <a href="#how" class="px-8 py-3 border border-white/70 text-white rounded-md font-semibold transition transform hover:scale-105 hover:bg-white/20">How It Works</a>
     </div>
   </section>
 
@@ -110,10 +110,9 @@
     <div class="max-w-xl mx-auto text-center px-4">
       <h2 class="text-2xl md:text-3xl font-semibold font-playfair">Join the future of decentralized money movement.</h2>
       <div class="mt-6 flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
-        <a href="#" class="px-6 py-3 bg-blue-600 text-white rounded-md font-semibold transition transform hover:scale-105 hover:shadow-lg">Request Early Access</a>
-        <a href="#about" class="px-6 py-3 border border-blue-600 text-blue-600 rounded-md font-semibold transition transform hover:scale-105 hover:shadow-lg">Contact Us</a>
+        <a href="#" class="px-6 py-3 bg-blue-600 text-white rounded-md font-semibold transition transform hover:scale-105 hover:bg-blue-700">Request Early Access</a>
+        <a href="#about" class="px-6 py-3 border border-blue-600 text-blue-600 rounded-md font-semibold transition transform hover:scale-105 hover:bg-blue-600 hover:text-white">Contact Us</a>
       </div>
-      <a href="#" class="mt-8 inline-block px-6 py-3 bg-yellow-500 text-white rounded-md font-semibold transition transform hover:scale-105 hover:shadow-lg">Join the Movement</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- point logo to root path
- enlarge hero heading on large screens
- simplify and polish hero buttons
- streamline CTA section and remove extra button

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687ff1c965408321a252a013f319920b