### PR TITLE
Apply dark mode design

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,27 +23,27 @@
     }
   </style>
 </head>
-<body class="text-gray-900 antialiased text-base leading-relaxed">
+<body class="bg-[#0c0c0c] text-white antialiased text-base leading-relaxed">
   <!-- Header -->
-  <header class="sticky top-0 z-20 backdrop-blur-md bg-white/70 shadow md:shadow-none md:bg-transparent flex items-center justify-between max-w-7xl mx-auto px-4 md:px-8 py-4 md:py-6">
-    <img src="hawalabit-logo.svg" alt="HawalaBit Logo" class="h-10 w-auto" />
+  <header class="sticky top-0 z-20 backdrop-blur-md bg-gray-900/70 shadow md:shadow-none flex items-center justify-between max-w-7xl mx-auto px-4 md:px-8 py-4 md:py-6">
+    <img src="assets/hawalabit-logo.svg" alt="HawalaBit Logo" class="h-10 w-auto" />
     
     <input type="checkbox" id="nav-toggle" class="peer hidden" />
     <label for="nav-toggle" class="md:hidden cursor-pointer">
-      <svg class="h-6 w-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg class="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
       </svg>
     </label>
-    <nav class="flex flex-col md:flex-row absolute md:static top-full left-0 w-full md:w-auto bg-white/80 backdrop-blur-md md:bg-transparent border-t md:border-0 space-y-2 md:space-y-0 md:space-x-8 py-4 md:py-0 text-base transition-all duration-300 overflow-hidden max-h-0 opacity-0 peer-checked:max-h-96 peer-checked:opacity-100 md:opacity-100 md:max-h-none">
-      <a href="#how" class="block px-4 md:px-0 py-2 text-gray-700 hover:text-gray-900">How It Works</a>
-      <a href="#about" class="block px-4 md:px-0 py-2 text-gray-700 hover:text-gray-900">About</a>
-      <a href="#cta" class="block px-4 md:px-0 py-2 text-gray-700 hover:text-gray-900">Get Started</a>
-      <a href="#cta" class="block px-4 md:px-0 py-2 text-blue-600 font-semibold hover:text-blue-800">Request Early Access</a>
+    <nav class="flex flex-col md:flex-row absolute md:static top-full left-0 w-full md:w-auto bg-gray-900/70 backdrop-blur-md md:bg-transparent border-t md:border-0 space-y-2 md:space-y-0 md:space-x-8 py-4 md:py-0 text-base transition-all duration-300 overflow-hidden max-h-0 opacity-0 peer-checked:max-h-96 peer-checked:opacity-100 md:opacity-100 md:max-h-none">
+      <a href="#how" class="block px-4 md:px-0 py-2 text-white hover:text-blue-400">How It Works</a>
+      <a href="#about" class="block px-4 md:px-0 py-2 text-white hover:text-blue-400">About</a>
+      <a href="#cta" class="block px-4 md:px-0 py-2 text-white hover:text-blue-400">Get Started</a>
+      <a href="#cta" class="block px-4 md:px-0 py-2 text-white font-semibold hover:text-blue-400">Request Early Access</a>
     </nav>
   </header>
 
   <!-- Hero -->
-  <section class="bg-gradient-to-r from-blue-500 via-purple-500 to-indigo-600 bg-animated py-20 text-center px-4 text-white" id="hero">
+  <section class="bg-gradient-to-br from-purple-800 via-blue-800 to-indigo-900 bg-animated py-20 text-center px-4 text-white" id="hero">
     <h1 class="text-4xl md:text-6xl font-bold font-playfair">Global Money. Human Trust. Instant Access.</h1>
     <p class="mt-4 text-xl leading-relaxed">Send, receive, and spend across borders—without banks or delays.</p>
     <div class="mt-8 flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
@@ -53,38 +53,38 @@
   </section>
 
   <!-- How It Works -->
-  <section class="py-16" id="how">
+  <section class="bg-gray-950 py-16" id="how">
     <div class="max-w-4xl mx-auto px-4">
-      <h2 class="text-2xl font-semibold text-center mb-8 font-playfair">How It Works</h2>
+      <h2 class="text-2xl font-semibold text-center mb-8 font-playfair text-white">How It Works</h2>
       <div class="grid gap-8 md:grid-cols-4 text-center">
         <div>
-          <div class="h-12 w-12 mx-auto mb-3 bg-gray-100 rounded-full flex items-center justify-center">1</div>
-          <p class="font-medium">Enter recipient details</p>
+          <div class="h-12 w-12 mx-auto mb-3 bg-white/10 border border-white/10 rounded-full flex items-center justify-center text-white">1</div>
+          <p class="font-medium text-gray-100">Enter recipient details</p>
         </div>
         <div>
-          <div class="h-12 w-12 mx-auto mb-3 bg-gray-100 rounded-full flex items-center justify-center">2</div>
-          <p class="font-medium">Connect your wallet / bank</p>
+          <div class="h-12 w-12 mx-auto mb-3 bg-white/10 border border-white/10 rounded-full flex items-center justify-center text-white">2</div>
+          <p class="font-medium text-gray-100">Connect your wallet / bank</p>
         </div>
         <div>
-          <div class="h-12 w-12 mx-auto mb-3 bg-gray-100 rounded-full flex items-center justify-center">3</div>
-          <p class="font-medium">Instantly send funds</p>
+          <div class="h-12 w-12 mx-auto mb-3 bg-white/10 border border-white/10 rounded-full flex items-center justify-center text-white">3</div>
+          <p class="font-medium text-gray-100">Instantly send funds</p>
         </div>
         <div>
-          <div class="h-12 w-12 mx-auto mb-3 bg-gray-100 rounded-full flex items-center justify-center">4</div>
-          <p class="font-medium">Recipient receives local equivalent</p>
+          <div class="h-12 w-12 mx-auto mb-3 bg-white/10 border border-white/10 rounded-full flex items-center justify-center text-white">4</div>
+          <p class="font-medium text-gray-100">Recipient receives local equivalent</p>
         </div>
       </div>
     </div>
   </section>
 
   <!-- Features -->
-  <section class="bg-gray-50 py-16" id="features">
+  <section class="bg-[#0f0f0f] py-16" id="features">
     <div class="max-w-4xl mx-auto px-4">
-      <div class="bg-white/30 backdrop-blur-md border border-white/20 shadow-lg rounded-lg p-8">
-        <ul class="space-y-4 text-lg">
-          <li class="flex items-start"><span class="text-green-600 mr-2">✅</span><span>Send globally, settle instantly</span></li>
-          <li class="flex items-start"><span class="text-green-600 mr-2">✅</span><span>Backed by human trust and blockchain security</span></li>
-          <li class="flex items-start"><span class="text-green-600 mr-2">✅</span><span>Built for mobile-first users and global families</span></li>
+      <div class="bg-black/30 border border-white/20 backdrop-blur-sm shadow-xl rounded-lg p-8">
+        <ul class="space-y-4 text-lg text-white text-opacity-90">
+          <li class="flex items-start"><span class="text-green-500 mr-2">✅</span><span>Send globally, settle instantly</span></li>
+          <li class="flex items-start"><span class="text-green-500 mr-2">✅</span><span>Backed by human trust and blockchain security</span></li>
+          <li class="flex items-start"><span class="text-green-500 mr-2">✅</span><span>Built for mobile-first users and global families</span></li>
         </ul>
       </div>
     </div>
@@ -93,35 +93,35 @@
   <!-- About Us -->
   <section class="py-16" id="about">
     <div class="max-w-3xl mx-auto px-4 text-center">
-      <blockquote class="text-lg text-gray-700 leading-relaxed">HawalaBit brings the centuries-old hawala system into the digital world. Designed for the global Somali diaspora, it combines traditional trust networks with instant USDT transactions and borderless access.</blockquote>
+      <blockquote class="text-lg text-white/80 leading-relaxed">HawalaBit brings the centuries-old hawala system into the digital world. Designed for the global Somali diaspora, it combines traditional trust networks with instant USDT transactions and borderless access.</blockquote>
     </div>
   </section>
 
   <!-- Trust -->
   <section class="py-16" id="trust">
     <div class="max-w-3xl mx-auto text-center px-4">
-      <h3 class="text-xl font-semibold font-playfair">Backed by the Central Bank of Somalia</h3>
-      <p class="mt-2 text-gray-700">Pioneered by Brock Pierce</p>
+      <h3 class="text-xl font-semibold font-playfair text-white">Backed by the Central Bank of Somalia</h3>
+      <p class="mt-2 text-white/70">Pioneered by Brock Pierce</p>
     </div>
   </section>
 
   <!-- Call To Action -->
-  <section class="bg-gray-50 py-16" id="cta">
+  <section class="bg-gray-900 py-16" id="cta">
     <div class="max-w-xl mx-auto text-center px-4">
-      <h2 class="text-2xl md:text-3xl font-semibold font-playfair">Join the future of decentralized money movement.</h2>
+      <h2 class="text-2xl md:text-3xl font-semibold font-playfair text-white">Join the future of decentralized money movement.</h2>
       <div class="mt-6 flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
         <a href="#" class="px-6 py-3 bg-blue-600 text-white rounded-md font-semibold transition transform hover:scale-105 hover:bg-blue-700">Request Early Access</a>
-        <a href="#about" class="px-6 py-3 border border-blue-600 text-blue-600 rounded-md font-semibold transition transform hover:scale-105 hover:bg-blue-600 hover:text-white">Contact Us</a>
+        <a href="#about" class="px-6 py-3 border border-blue-500 text-blue-500 rounded-md font-semibold transition transform hover:scale-105 hover:bg-blue-500 hover:text-white">Contact Us</a>
       </div>
     </div>
   </section>
 
   <!-- Footer -->
-  <footer class="py-8 text-center text-sm text-gray-500">
+  <footer class="bg-[#0c0c0c] py-8 text-center text-sm text-gray-400">
     <div class="space-x-4 mb-4">
-      <a href="#how" class="hover:underline">Nav</a>
-      <a href="#" class="hover:underline">Legal</a>
-      <a href="#" class="hover:underline">Social</a>
+      <a href="#how" class="text-gray-400 hover:text-white hover:underline">Nav</a>
+      <a href="#" class="text-gray-400 hover:text-white hover:underline">Legal</a>
+      <a href="#" class="text-gray-400 hover:text-white hover:underline">Social</a>
     </div>
     <p>&copy; 2025 HawalaBit</p>
   </footer>


### PR DESCRIPTION
## Summary
- switch to a dark background and light text
- restyle navigation and hero gradient
- darken all sections and feature cards
- update about, trust, CTA and footer styles
- use logo from assets folder

## Testing
- `apt-get update` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687ff5058670832187db47b34049de47