### PR TITLE
Fix interactive grid visibility on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   </style>
 </head>
 <body class="relative bg-[#0c0c0c] text-white antialiased text-base leading-relaxed">
-  <div id="grid-root"></div>
+  <div id="grid-root" class="absolute inset-0 z-0 hidden md:block pointer-events-none"></div>
 <div class="relative z-10">
   <!-- Header (more transparent for grid visibility) -->
   <input type="checkbox" id="nav-toggle" class="peer hidden" />
@@ -239,7 +239,7 @@
           height="100%"
           viewBox={`0 0 ${size * horizontal} ${size * vertical}`}
           preserveAspectRatio="xMidYMid slice"
-          className="absolute inset-0 z-0 hidden md:block w-full h-[200%] inset-y-[-30%] skew-y-12 [mask-image:radial-gradient(400px_circle_at_center,white,transparent)]"
+          className="pointer-events-none absolute inset-0 z-0 hidden md:block w-full h-[200%] inset-y-[-30%] skew-y-12 [mask-image:radial-gradient(400px_circle_at_center,white,transparent)]"
         >
           {Array.from({ length: horizontal * vertical }).map((_, index) => {
             const x = (index % horizontal) * size;
@@ -252,8 +252,8 @@
                 width={size}
                 height={size}
                 className={
-                  `stroke-white/10 transition-all duration-100 ease-in-out ` +
-                  (hovered === index ? "fill-purple-500/10" : "fill-transparent")
+                  "stroke-white/10 transition-all duration-100 ease-in-out " +
+                  (hovered === index ? "fill-purple-500/10" : "fill-purple-500/5")
                 }
                 onMouseEnter={() => setHovered(index)}
                 onMouseLeave={() => setHovered(null)}


### PR DESCRIPTION
## Summary
- style `#grid-root` so the React grid fills the screen behind content
- prevent the grid `<svg>` from intercepting pointer events
- tune the default rectangle fill color for better contrast

## Testing
- `npx tailwindcss -i src/styles.css -o dist/output.css --minify` *(fails: No prebuild or local build of @parcel/watcher found)*

------
https://chatgpt.com/codex/tasks/task_e_68812bc9d0c8832189b263ce144712f8